### PR TITLE
test-Monitors: appease security format string warning

### DIFF
--- a/test/test-Monitors.cpp
+++ b/test/test-Monitors.cpp
@@ -33,7 +33,7 @@ protected:
         ASSERT_EQ(0, mkdir("./lid/LIDX", 0755));
         FILE *lidStateFile = fopen("./lid/LIDX/state", "w");
         ASSERT_TRUE(lidStateFile != nullptr);
-        fprintf(lidStateFile, contents);
+        fputs(contents, lidStateFile);
         ASSERT_EQ(0, fclose(lidStateFile));
     };
 };


### PR DESCRIPTION
Fixes build when using toolchains that treat this as an error.