### PR TITLE
Enable per-monitor copy settings

### DIFF
--- a/src/Settings.h
+++ b/src/Settings.h
@@ -18,6 +18,7 @@
 
 #include <string>
 #include <vector>
+#include <map>
 
 // user provided settings for this utility
 class Settings {
@@ -28,6 +29,7 @@ public:
     bool noop = false;
     bool mirror = false;
     std::vector<std::string> order;
+    std::map<std::string, std::string> copy;
     std::string primary;
     bool quiet = false;
 };

--- a/src/calculations.h
+++ b/src/calculations.h
@@ -17,6 +17,7 @@
 #define XLAYOUTDISPLAY_CALCULATIONS_H
 
 #include <vector>
+#include <map>
 #include "Output.h"
 
 #define DEFAULT_DPI 96
@@ -30,8 +31,8 @@ const std::list<std::shared_ptr<Output>> orderOutputs(const std::list<std::share
 const std::shared_ptr<Output> activateOutputs(const std::list<std::shared_ptr<Output>> &outputs,
                                               const std::string &desiredPrimary, const Monitors &monitors);
 
-// arrange outputs left to right at optimal mode; will mutate contents
-void ltrOutputs(const std::list<std::shared_ptr<Output>> &outputs);
+// arrange outputs left to right at optimal mode; copy all outputs that should be copied; will mutate contents
+void ltrOutputs(const std::list<std::shared_ptr<Output>> &outputs, const std::map<std::string, std::string>& copies);
 
 // arrange outputs so that they all mirror at highest common mode; will mutate contents
 // throws runtime_error:

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -61,7 +61,7 @@ int layout(const Settings &settings) {
     if (settings.mirror) {
         mirrorOutputs(outputs);
     } else {
-        ltrOutputs(outputs);
+        ltrOutputs(outputs, settings.copy);
     }
 
     // determine DPI from the primary


### PR DESCRIPTION
This PR enables `-c` flag, which will allow user to specify per-monitor display copying.