### PR TITLE
add -w argument, update udev rule and instructions

### DIFF
--- a/.xlayoutdisplay
+++ b/.xlayoutdisplay
@@ -16,3 +16,5 @@
 # override calculated DPI
 #dpi=192
 
+# wait seconds before acting
+#wait=10

--- a/99-xlayoutdisplay.rules
+++ b/99-xlayoutdisplay.rules
@@ -1,1 +1,9 @@
-ACTION=="change", SUBSYSTEM=="drm", ENV{DISPLAY}=":0", ENV{XAUTHORITY}="/home/{username}/.Xauthority", RUN+="/usr/bin/xlayoutdisplay"
+ACTION=="change", SUBSYSTEM=="drm", GOTO="xlayoutdisplay"
+
+LABEL="xlayoutdisplay"
+
+ENV{HOME}="/home/username"
+ENV{DISPLAY}=":0"
+ENV{XAUTHORITY}="$env{HOME}/.Xauthority"
+
+RUN+="/bin/sh -c 'xlayoutdisplay >> /tmp/xlayoutdisplay.udev.log 2>&1'"

--- a/99-xlayoutdisplay.rules
+++ b/99-xlayoutdisplay.rules
@@ -1,1 +1,1 @@
-ACTION=="change", SUBSYSTEM=="drm", ENV{HOME}="/home/username", ENV{DISPLAY}=":0", ENV{XAUTHORITY}="$env{HOME}/.Xauthority", RUN+="/bin/sh -c 'xlayoutdisplay -w 10 >> /tmp/xlayoutdisplay.udev.log 2>&1'"
+ACTION=="change", SUBSYSTEM=="drm", ENV{HOME}="/home/username", ENV{DISPLAY}=":0", ENV{XAUTHORITY}="$env{HOME}/.Xauthority", RUN+="/bin/sh -c 'xlayoutdisplay -w 5 >> /tmp/xlayoutdisplay.udev.log 2>&1'"

--- a/99-xlayoutdisplay.rules
+++ b/99-xlayoutdisplay.rules
@@ -1,9 +1,1 @@
-ACTION=="change", SUBSYSTEM=="drm", GOTO="xlayoutdisplay"
-
-LABEL="xlayoutdisplay"
-
-ENV{HOME}="/home/username"
-ENV{DISPLAY}=":0"
-ENV{XAUTHORITY}="$env{HOME}/.Xauthority"
-
-RUN+="/bin/sh -c 'xlayoutdisplay >> /tmp/xlayoutdisplay.udev.log 2>&1'"
+ACTION=="change", SUBSYSTEM=="drm", ENV{HOME}="/home/username", ENV{DISPLAY}=":0", ENV{XAUTHORITY}="$env{HOME}/.Xauthority", RUN+="/bin/sh -c 'xlayoutdisplay -w 10 >> /tmp/xlayoutdisplay.udev.log 2>&1'"

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To automatically run `xlayoutdisplay` whenever a new display is plugged in or un
 A sample rule can be found at [99-xlayoutdisplay.rules](99-xlayoutdisplay.rules).    
 Simply update the value of `ENV{HOME}`, and copy the customized file to `/etc/udev/rules.d/`.    
 
-A wait time e.g. 5 seconds is necessary to allow Xorg time to enumerate new monitors.
+The wait time is necessary to allow Xorg time to enumerate new monitors.
 
 Additional informations can be found at the [`udev` Arch Wiki article](https://wiki.archlinux.org/title/Udev#Execute_when_HDMI_cable_is_plugged_in_or_unplugged).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Highest refresh rate of the output's preferred resolution are used.
 
 Left-to-right ordering is used, unless the user specifies mirrorred outputs.
 
-Laptop displays (eDP*) are disabled when the lid is closed.
+Laptop displays `eDP.*` are disabled when the lid is closed.
 
 Wayland equivalent: [way-displays](https://github.com/alex-courtis/way-displays).
 
@@ -64,7 +64,7 @@ To automatically run `xlayoutdisplay` whenever a new display is plugged in or un
 A sample rule can be found at [99-xlayoutdisplay.rules](99-xlayoutdisplay.rules).    
 Simply update the value of `ENV{HOME}`, and copy the customized file to `/etc/udev/rules.d/`.    
 
-The wait time is necessary to allow Xorg time to enumerate new monitors.
+The wait time is necessary to allow Xorg time to enumerate new monitors. 5 seconds is a conservative value; experiment with smaller values for better response time.
 
 Additional informations can be found at the [`udev` Arch Wiki article](https://wiki.archlinux.org/title/Udev#Execute_when_HDMI_cable_is_plugged_in_or_unplugged).
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ CLI, $XDG_CONFIG_HOME/.xlayoutdisplay, $HOME/.xlayoutdisplay and /etc/xlayoutdis
   -o [ --order ] arg     order of outputs, repeat as needed
   -p [ --primary ] arg   primary output
   -q [ --quiet ]         suppress feedback
+  -w [ --wait ] arg      wait seconds before running
 ```
 
 ## Installation
@@ -61,7 +62,9 @@ See [xlayoutdisplay](.xlayoutdisplay)
 To automatically run `xlayoutdisplay` whenever a new display is plugged in or unplugged, `udev` can be used.    
 
 A sample rule can be found at [99-xlayoutdisplay.rules](99-xlayoutdisplay.rules).    
-Simply replace the path of `ENV{XAUTHORITY}` with the output of `printenv XAUTHORITY`, and copy the customized file to `/etc/udev/rules.d/`.    
+Simply update the value of `ENV{HOME}`, and copy the customized file to `/etc/udev/rules.d/`.    
+
+A wait time e.g. 5 seconds is necessary to allow Xorg time to enumerate new monitors.
 
 Additional informations can be found at the [`udev` Arch Wiki article](https://wiki.archlinux.org/title/Udev#Execute_when_HDMI_cable_is_plugged_in_or_unplugged).
 

--- a/main.cpp
+++ b/main.cpp
@@ -47,18 +47,19 @@ void usage(std::ostream &os) {
         "e.g.  xlayoutdisplay -p DP-4 -o HDMI-0 -o DP-4\n"
         "\n"
         "CLI:\n"
-        "-h [ --help ]          print this help text and exit\n"
-        "-i [ --info ]          print information about current outputs and exit\n"
-        "-n [ --noop ]          perform a trial run and exit\n"
-        "-v [ --version ]       print version string\n"
+        "  -h [ --help ]          print this help text and exit\n"
+        "  -i [ --info ]          print information about current outputs and exit\n"
+        "  -n [ --noop ]          perform a trial run and exit\n"
+        "  -v [ --version ]       print version string\n"
         "\n"
         "CLI, $XDG_CONFIG_HOME/.xlayoutdisplay, $HOME/.xlayoutdisplay and /etc/xlayoutdisplay:\n"
-        "-d [ --dpi ] arg       DPI override\n"
-        "-r [ --rate ] arg      Refresh rate override\n"
-        "-m [ --mirror ]        mirror outputs using the lowest common resolution\n"
-        "-o [ --order ] arg     order of outputs, repeat as needed\n"
-        "-p [ --primary ] arg   primary output\n"
-        "-q [ --quiet ]         suppress feedback\n";
+        "  -d [ --dpi ] arg       DPI override\n"
+        "  -r [ --rate ] arg      Refresh rate override\n"
+        "  -m [ --mirror ]        mirror outputs using the lowest common resolution\n"
+        "  -o [ --order ] arg     order of outputs, repeat as needed\n"
+        "  -p [ --primary ] arg   primary output\n"
+        "  -q [ --quiet ]         suppress feedback\n"
+        "  -w [ --wait ] arg      wait seconds before running\n";
 }
 
 void parseCfgFile(ifstream &ifs, Settings &settings) {
@@ -88,6 +89,8 @@ void parseCfgFile(ifstream &ifs, Settings &settings) {
             settings.primary = match[2];
         } else if (match[1] == "quiet") {
             settings.quiet = parseBool(match[2]);
+        } else if (match[1] == "wait") {
+            settings.wait = parseLong(match[1], match[2]);
         } else {
             throw invalid_argument("unrecognised file option '" + match[0].str() + "'");
         }
@@ -107,9 +110,10 @@ void parseArgs(int argc, char **argv, Settings &settings) {
         { "order",         required_argument, 0, 'o' },
         { "primary",       required_argument, 0, 'p' },
         { "quiet",         no_argument,       0, 'q' },
+        { "wait",          required_argument, 0, 'w' },
         { 0,               0,                 0,  0  }
     };
-    static const char *short_options = "hinvd:r:mo:p:q";
+    static const char *short_options = "hinvd:r:mo:p:qw:";
 
     bool orderFromFile = !settings.order.empty();
 
@@ -153,6 +157,9 @@ void parseArgs(int argc, char **argv, Settings &settings) {
                 break;
             case 'q':
                 settings.quiet = true;
+                break;
+            case 'w':
+                settings.wait = parseLong("wait", optarg);;
                 break;
             case '?':
             default:

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -30,6 +30,7 @@ public:
     std::vector<std::string> order;
     std::string primary;
     bool quiet = false;
+    long wait = 0;
 };
 
 #endif //XLAYOUTDISPLAY_SETTINGS_H

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -20,10 +20,19 @@
 #include "xutil.h"
 #include "calculations.h"
 #include <iostream>
+#include <unistd.h>
 
 using namespace std;
 
 int layout(const Settings &settings) {
+
+    // optional wait
+    if (settings.wait) {
+        if (!settings.quiet) {
+            cout << "Waiting " << settings.wait << " seconds..." << endl;
+        }
+        sleep(settings.wait);
+    }
 
     // discover monitors
     const Monitors monitors = Monitors();

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -26,6 +26,12 @@ using namespace std;
 
 int layout(const Settings &settings) {
 
+    // don't attempt a connection when Xorg not running, to prevent
+    // https://wiki.archlinux.org/title/Udev#X_programs_in_RUN_rules_hang_when_no_X_server_is_present
+    if (!xorgRunning()) {
+        throw runtime_error("Xorg not running");
+    }
+
     // optional wait
     if (settings.wait) {
         if (!settings.quiet) {

--- a/src/xrandrrutil.cpp
+++ b/src/xrandrrutil.cpp
@@ -14,7 +14,6 @@
    limitations under the License.
 */
 #include "xrandrrutil.h"
-#include "xutil.h"
 
 #include <sstream>
 #include <cstring>
@@ -91,12 +90,6 @@ Mode *modeFromXRR(RRMode id, const XRRScreenResources *resources) {
 // build a list of Output based on the current and possible state of the world
 const list<shared_ptr<Output>> discoverOutputs() {
     list<shared_ptr<Output>> outputs;
-
-    // don't attempt a connection when Xorg not running, to prevent
-    // https://wiki.archlinux.org/title/Udev#X_programs_in_RUN_rules_hang_when_no_X_server_is_present
-    if (!xorgRunning()) {
-        throw runtime_error("Xorg not running");
-    }
 
     // get the display
     Display *dpy = XOpenDisplay(nullptr);


### PR DESCRIPTION
Add `-w` option. Necessary for Xorg to handshake with new monitors.

Update udev rule to include $HOME to allow usage of user configuration files.

Follows #22 